### PR TITLE
Set EXROM to input on startup instead of output

### DIFF
--- a/SKS64_SKETCH/SKS64_SKETCH.ino
+++ b/SKS64_SKETCH/SKS64_SKETCH.ino
@@ -174,7 +174,7 @@ void setup() {
   digitalWrite(A14, LOW);
   digitalWrite(INTRST, HIGH);
   if(exrom_available) {
-    pinMode(EXROM, OUTPUT);
+    pinMode(EXROM, INPUT);
     digitalWrite(EXROM, HIGH);
   }
 


### PR DESCRIPTION
With the startup code setting EXROM as an output, then it would be held high until the first reset (which leaves it as an input, so high impedance)